### PR TITLE
Implement address entry on order placement

### DIFF
--- a/main.py
+++ b/main.py
@@ -86,6 +86,7 @@ class CartItem(BaseModel):
 
 class CheckoutRequest(BaseModel):
     items: List[CartItem]
+    address: str
 
 
 class ResetRequest(BaseModel):
@@ -298,7 +299,10 @@ async def checkout(
     current_user: dict = Depends(get_current_user_from_token),
     db: Session = Depends(get_db)
 ):
-    order = Order(buyer=current_user["username"])
+    order = Order(
+        buyer=current_user["username"],
+        address=request.address,
+    )
     db.add(order)
     db.flush()  # Get order.id
 
@@ -402,6 +406,7 @@ def get_seller_orders(current_user: dict = Depends(get_current_user_from_token),
     return [{
         "id": order.id,
         "buyer": order.buyer,
+        "address": order.address,
         "items": [{
             "name": item.product.name,
             "price": item.product.price,

--- a/models.py
+++ b/models.py
@@ -2,6 +2,8 @@
 from sqlalchemy import Column, Integer, String, Float, ForeignKey
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
+from sqlalchemy import DateTime
+from datetime import datetime
 from pydantic import BaseModel
 from typing import List
 
@@ -33,6 +35,9 @@ class Order(Base):
     __tablename__ = "orders"
     id = Column(Integer, primary_key=True)
     buyer = Column(String)
+    address = Column(String)
+    status = Column(String, default="Pending")
+    timestamp = Column(DateTime, default=datetime.utcnow)
     items = relationship("OrderItem", back_populates="order")
 
 

--- a/static/cart.html
+++ b/static/cart.html
@@ -63,8 +63,6 @@
     <p id="total"></p>
     <button onclick="placeOrder()">Place Order</button>
     <button onclick="goBack()">Back to Products</button>
-    <button onclick="checkoutCart()">Checkout</button>
-    <p id="checkout-msg"></p>
 
     <script>
         let cart = JSON.parse(localStorage.getItem("cart")) || [];
@@ -110,27 +108,14 @@
             renderCart();
         }
 
-        function placeOrder() {
+        async function placeOrder() {
             if (cart.length === 0) return alert("Your cart is empty.");
-            // You can integrate backend API here later
-            localStorage.removeItem("cart");
-            cart = [];
-            document.getElementById("message").textContent = "Order placed successfully!";
-            renderCart();
-        }
 
-        function goBack() {
-            window.location.href = "/static/buyers.html";
-        }
+            const address = prompt("Enter delivery address:");
+            if (!address) return;
 
-        async function checkoutCart() {
             const token = localStorage.getItem("access_token");
-            const cart = JSON.parse(localStorage.getItem("cart") || "[]");
-
-            if (!cart.length) {
-                document.getElementById("checkout-msg").textContent = "Your cart is empty.";
-                return;
-            }
+            const items = cart.map(item => ({ product_id: item.id, quantity: item.qty }));
 
             try {
                 const res = await fetch("/checkout", {
@@ -139,19 +124,27 @@
                         "Content-Type": "application/json",
                         Authorization: "Bearer " + token,
                     },
-                    body: JSON.stringify({ items: cart }),
+                    body: JSON.stringify({ items, address }),
                 });
 
                 const data = await res.json();
-                if (!res.ok) throw new Error(data.detail || "Checkout failed");
+                if (!res.ok) throw new Error(data.detail || "Order failed");
 
-                localStorage.removeItem("cart"); // Clear cart on success
-                document.getElementById("checkout-msg").textContent = data.msg || "Order placed successfully!";
+                localStorage.removeItem("cart");
+                cart = [];
+                document.getElementById("message").style.color = "green";
+                document.getElementById("message").textContent = data.msg || "Order placed successfully!";
+                renderCart();
             } catch (err) {
-                document.getElementById("checkout-msg").style.color = "red";
-                document.getElementById("checkout-msg").textContent = err.message;
+                document.getElementById("message").style.color = "red";
+                document.getElementById("message").textContent = err.message;
             }
         }
+
+        function goBack() {
+            window.location.href = "/static/buyers.html";
+        }
+
 
         async function checkOrderNotifications() {
             const token = localStorage.getItem("access_token");


### PR DESCRIPTION
## Summary
- remove unused checkout button
- prompt for address when placing an order and send it to the API
- extend backend `CheckoutRequest` and `/checkout` endpoint to store address
- extend `Order` model with `address`, `status` and `timestamp`
- expose order address in seller order listing

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6863d12c90c0832fa6e4fec6bc0c8ddf