### PR TITLE
Fix order flow by adding address input

### DIFF
--- a/static/cart.html
+++ b/static/cart.html
@@ -43,6 +43,13 @@
             text-align: center;
             color: green;
         }
+
+        #address-input {
+            width: 100%;
+            padding: 8px;
+            margin-top: 10px;
+            box-sizing: border-box;
+        }
     </style>
 </head>
 
@@ -61,6 +68,7 @@
         <tbody></tbody>
     </table>
     <p id="total"></p>
+    <textarea id="address-input" placeholder="Enter delivery address" rows="3"></textarea>
     <button onclick="placeOrder()">Place Order</button>
     <button onclick="goBack()">Back to Products</button>
 
@@ -111,8 +119,11 @@
         async function placeOrder() {
             if (cart.length === 0) return alert("Your cart is empty.");
 
-            const address = prompt("Enter delivery address:");
-            if (!address) return;
+            const address = document.getElementById("address-input").value.trim();
+            if (!address) {
+                alert("Please enter delivery address.");
+                return;
+            }
 
             const token = localStorage.getItem("access_token");
             const items = cart.map(item => ({ product_id: item.id, quantity: item.qty }));
@@ -132,6 +143,7 @@
 
                 localStorage.removeItem("cart");
                 cart = [];
+                document.getElementById("address-input").value = "";
                 document.getElementById("message").style.color = "green";
                 document.getElementById("message").textContent = data.msg || "Order placed successfully!";
                 renderCart();


### PR DESCRIPTION
## Summary
- add an address text area to the cart page
- read the address from the input instead of using `prompt`
- clear the input after a successful order

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6863d38c5744832fa2810e918edcbf04