### PR TITLE
Remove duplicate POST /register route

### DIFF
--- a/main.py
+++ b/main.py
@@ -526,13 +526,6 @@ def register_form(request: Request):
     return templates.TemplateResponse("register.html", {"request": request})
 
 
-@app.post("/register")
-def register_user(username: str = Form(...), password: str = Form(...), full_name: str = Form(...)):
-    # TODO: Add logic to save the user to your database
-    print(f"Registered: {username}, {full_name}")
-    return RedirectResponse(url="/login", status_code=303)
-
-
 @app.post("/send-reset-link")
 async def send_reset_link(payload: ResetRequest):
     # Generate unique token


### PR DESCRIPTION
## Summary
- delete the placeholder `register_user` handler so only one POST route exists for `/register`

## Testing
- `python -m py_compile auth.py database.py main.py models.py schemas.py`


------
https://chatgpt.com/codex/tasks/task_e_6863e86de2a8832fb0c07220d05cba2d