### PR TITLE
Implement admin product validation

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,5 +1,5 @@
 # models.py
-from sqlalchemy import Column, Integer, String, Float, ForeignKey
+from sqlalchemy import Column, Integer, String, Float, ForeignKey, Boolean
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
 from sqlalchemy import DateTime
@@ -29,6 +29,7 @@ class Product(Base):
     seller = Column(String)
     shop_name = Column(String)
     image_url = Column(String)  # Add this line
+    is_validated = Column(Boolean, default=False)
     delivery_range_km = Column(Integer)
     expiry_datetime = Column(String)
 


### PR DESCRIPTION
## Summary
- add `is_validated` field to products
- only list validated products for buyers
- block purchases of unvalidated products
- provide admin endpoints to approve or delete products

## Testing
- `python -m py_compile main.py models.py schemas.py database.py`

------
https://chatgpt.com/codex/tasks/task_e_686514c2b210832fa316c910abb3fc6e