### PR TITLE
Fix templates directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,7 @@ RangeCart/
 │
 ├── main.py           # Main FastAPI backend
 ├── models.py         # Data models (User, Product, etc.)
-├── templates/        # HTML files (Jinja2)
-├── static/           # Frontend files
+├── static/           # Frontend files and HTML templates
 ├── database.py       # Database setup
 ├── requirements.txt  # Required packages
 ```

--- a/main.py
+++ b/main.py
@@ -614,7 +614,8 @@ def get_product(
     }
 
 
-templates = Jinja2Templates(directory="templates")  # Update path if needed
+# Load HTML templates from the same directory as other static files
+templates = Jinja2Templates(directory="static")
 
 
 @app.get("/forgot-password", response_class=HTMLResponse)


### PR DESCRIPTION
## Summary
- serve forgot password and register templates from static folder
- fix folder layout docs

## Testing
- `python -m py_compile main.py` *(fails: invalid syntax in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68651cf1a7e8832f89c317d211e873b0