### PR TITLE
Implement expired product cleanup

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,16 @@
+# Project Task List
+
+This file tracks future work for the RangeCart project.
+
+## Admin Features
+- [ ] Create an admin dashboard page for reviewing pending products.
+- [ ] Provide UI for admins to validate or delete products from the dashboard.
+- [ ] Add a page where admins can view all registered sellers.
+
+## Password Reset
+- [ ] Implement real WhatsApp or email integration to send reset links.
+
+## Other Improvements
+- [x] Automatically remove expired products with a background job.
+- [ ] Write tests for admin and seller endpoints.
+- [ ] Add notifications for buyers when orders are fulfilled.

--- a/main.py
+++ b/main.py
@@ -26,9 +26,10 @@ from jose import JWTError, jwt
 from datetime import datetime, timedelta
 import json
 import os
+import asyncio
 from sqlalchemy.orm import Session
 from models import Base, Order, OrderItem, UserModel as DBUser, Product as DBProduct
-from database import engine, get_db
+from database import engine, get_db, SessionLocal
 from schemas import ProductOut
 from fastapi.templating import Jinja2Templates
 import uuid
@@ -36,6 +37,28 @@ import uuid
 app = FastAPI()
 app.mount("/static", StaticFiles(directory="static"), name="static")
 Base.metadata.create_all(bind=engine)
+
+
+async def cleanup_expired_products():
+    """Periodically remove products past their expiry time."""
+    while True:
+        db = SessionLocal()
+        now = datetime.utcnow()
+        for product in db.query(DBProduct).all():
+            try:
+                expiry = datetime.fromisoformat(product.expiry_datetime)
+            except Exception:
+                continue
+            if expiry < now:
+                db.delete(product)
+        db.commit()
+        db.close()
+        await asyncio.sleep(3600)
+
+
+@app.on_event("startup")
+async def start_background_tasks():
+    asyncio.create_task(cleanup_expired_products())
 
 # Serve static frontend files
 


### PR DESCRIPTION
## Summary
- add a periodic cleanup task that deletes expired products
- mark the cleanup task as done in `TASKS.md`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686522de72a4832f8d00741a81d2e971