### PR TITLE
Fix products endpoint early return

### DIFF
--- a/main.py
+++ b/main.py
@@ -337,13 +337,9 @@ async def get_products(
     db: Session = Depends(get_db),
 ):
 
-    db_products = db.query(DBProduct).filter(DBProduct.is_validated == True).all()
-
-    return
-
-
     """Return all validated products for the marketplace."""
 
+    db_products = db.query(DBProduct).filter(DBProduct.is_validated == True).all()
 
     products = []
     for p in db_products:


### PR DESCRIPTION
## Summary
- fix `/products` API function so it returns list of products instead of `null`

## Testing
- `python -m py_compile main.py models.py database.py schemas.py`


------
https://chatgpt.com/codex/tasks/task_e_68653dfc0a98832f8b574c43f3cc34c9