### PR TITLE
Remove dead register route

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@
 5. Open your browser and go to:
    [http://127.0.0.1:8000](http://127.0.0.1:8000)
 
+   Registration is handled directly on this page; there is no separate
+   `/register` form route.
+
 ---
 
 ## Managing Shop Names

--- a/main.py
+++ b/main.py
@@ -646,9 +646,10 @@ async def process_forgot_password(email: str = Form(...)):
     return RedirectResponse(url="/login", status_code=303)
 
 
-@app.get("/register", response_class=HTMLResponse)
-def register_form(request: Request):
-    return templates.TemplateResponse("register.html", {"request": request})
+# Registration is handled on the main page. The old form route is no longer used.
+# @app.get("/register", response_class=HTMLResponse)
+# def register_form(request: Request):
+#     return templates.TemplateResponse("register.html", {"request": request})
 
 
 @app.post("/send-reset-link")


### PR DESCRIPTION
## Summary
- comment out unused GET /register handler
- clarify in the README that registration happens on the main page

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_686a0420bb3c832fb304002bfd559fed