### PR TITLE
Add admin registration page

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ These values appear on the seller dashboard where they can be edited anytime.
 
 ## Admin Users
 
-Create an admin account by sending a role of `"admin"` when registering:
+Create an admin account by sending a role of `"admin"` when registering or by visiting the browser based form at `/admin/register`:
 
 ```bash
 curl -X POST -H "Content-Type: application/json" \

--- a/main.py
+++ b/main.py
@@ -727,3 +727,9 @@ async def admin_dashboard_page():
 async def admin_sellers_page():
     """Serve the seller list HTML for admins."""
     return FileResponse("static/admin_sellers.html")
+
+
+@app.get("/admin/register", include_in_schema=False)
+async def admin_register_page():
+    """Serve the admin registration form."""
+    return FileResponse("static/admin_register.html")

--- a/static/admin_register.html
+++ b/static/admin_register.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Admin Registration</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 400px;
+            margin: 40px auto;
+            padding: 20px;
+            border: 1px solid #ddd;
+            border-radius: 10px;
+        }
+        input {
+            width: 100%;
+            padding: 8px;
+            margin: 6px 0;
+            box-sizing: border-box;
+        }
+        button {
+            padding: 10px 16px;
+            background-color: #007bff;
+            color: white;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
+        }
+        button:hover {
+            background-color: #0056b3;
+        }
+        #msg {
+            margin-top: 10px;
+            font-weight: bold;
+        }
+    </style>
+</head>
+<body>
+    <h2>Admin Registration</h2>
+    <input type="text" id="username" placeholder="Username" />
+    <input type="text" id="full_name" placeholder="Full Name" />
+    <input type="password" id="password" placeholder="Password" />
+    <button onclick="registerAdmin()">Register</button>
+    <p id="msg"></p>
+    <p><a href="/static/index.html">Back to Login</a></p>
+
+    <script>
+        async function registerAdmin() {
+            const payload = {
+                username: document.getElementById('username').value.trim(),
+                full_name: document.getElementById('full_name').value.trim(),
+                password: document.getElementById('password').value,
+                role: ['admin']
+            };
+            document.getElementById('msg').textContent = '';
+            const res = await fetch('/register', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            });
+            const data = await res.json();
+            if (res.ok) {
+                document.getElementById('msg').textContent = data.msg;
+                document.getElementById('msg').style.color = 'green';
+            } else {
+                document.getElementById('msg').textContent = data.detail || 'Error';
+                document.getElementById('msg').style.color = 'red';
+            }
+        }
+    </script>
+</body>
+</html>

--- a/static/index.html
+++ b/static/index.html
@@ -103,6 +103,8 @@
       <p class="switch">New user? <a href="#" onclick="toggleRegister()">Register here</a>
         <span class="divider">|</span>
         <a href="#" onclick="toggleForgotPassword()">Forgot Password?</a>
+        <span class="divider">|</span>
+        <a href="/admin/register">Admin? Register here</a>
       </p>
 
     </div>


### PR DESCRIPTION
## Summary
- create `admin_register.html` for admin onboarding
- serve the admin registration page from `/admin/register`
- link to admin registration from login page
- document admin registration page in README

## Testing
- `python -m py_compile main.py database.py models.py schemas.py`

------
https://chatgpt.com/codex/tasks/task_e_686a0d5dc998832fbaa41477379225f6