### PR TITLE
Use UUID filenames for uploads

### DIFF
--- a/main.py
+++ b/main.py
@@ -33,6 +33,8 @@ from database import engine, get_db, SessionLocal
 from schemas import ProductOut
 from fastapi.templating import Jinja2Templates
 import uuid
+from uuid import uuid4
+from pathlib import Path
 
 app = FastAPI()
 app.mount("/static", StaticFiles(directory="static"), name="static")
@@ -303,7 +305,9 @@ async def create_product(
     image_urls = []
 
     for image in images:
-        image_path = f"static/uploads/{image.filename}"
+        ext = Path(image.filename).suffix
+        filename = f"{uuid4().hex}{ext}"
+        image_path = Path("static/uploads") / filename
         with open(image_path, "wb") as buffer:
             buffer.write(await image.read())
         image_urls.append(f"/{image_path}")  # store with /static path


### PR DESCRIPTION
## Summary
- generate a unique filename for each uploaded image
- import `uuid4` and `Path` for upload handling

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686d10fe6d28832f87ae9962473063ef