### PR TITLE
Enforce kinbech username format

### DIFF
--- a/main.py
+++ b/main.py
@@ -177,15 +177,30 @@ def get_current_user_from_token(
         raise HTTPException(status_code=401, detail="Invalid token")
 
 
+def _generate_unique_username(base: str, db: Session) -> str:
+    """Generate a unique username with the kinbech.com domain."""
+    while True:
+        candidate = f"{base}{uuid4().hex[:5]}@kinbech.com"
+        if not db.query(DBUser).filter(DBUser.username == candidate).first():
+            return candidate
+
+
 @app.post("/register", status_code=201)
 async def register(user: UserCreate, db: Session = Depends(get_db)):
-    existing = db.query(DBUser).filter(DBUser.username == user.username).first()
+    base_name = user.username.split("@")[0]
+    username = f"{base_name}@kinbech.com"
+
+    existing = db.query(DBUser).filter(DBUser.username == username).first()
     if existing:
-        raise HTTPException(status_code=400, detail="Username already registered")
+        suggestion = _generate_unique_username(base_name, db)
+        raise HTTPException(
+            status_code=400,
+            detail=f"Username already registered. Suggested username: {suggestion}",
+        )
 
     hashed_password = get_password_hash(user.password)
     db_user = DBUser(
-        username=user.username,
+        username=username,
         full_name=user.full_name,
         hashed_password=hashed_password,
 

--- a/static/admin.html
+++ b/static/admin.html
@@ -62,8 +62,12 @@
             window.location.href = "/static/index.html";
         }
         async function createUser(){
+            let uname = document.getElementById('username').value.trim();
+            if(!uname.endsWith('@kinbech.com')){
+                uname = uname + '@kinbech.com';
+            }
             const payload = {
-                username: document.getElementById('username').value.trim(),
+                username: uname,
                 full_name: document.getElementById('full_name').value.trim(),
                 password: document.getElementById('password').value,
                 role: Array.from(document.getElementById('roles').selectedOptions).map(o=>o.value)

--- a/static/admin_register.html
+++ b/static/admin_register.html
@@ -47,8 +47,12 @@
 
     <script>
         async function registerAdmin() {
+            let uname = document.getElementById('username').value.trim();
+            if(!uname.endsWith('@kinbech.com')){
+                uname = uname + '@kinbech.com';
+            }
             const payload = {
-                username: document.getElementById('username').value.trim(),
+                username: uname,
                 full_name: document.getElementById('full_name').value.trim(),
                 password: document.getElementById('password').value,
                 role: ['admin']

--- a/static/index.html
+++ b/static/index.html
@@ -136,7 +136,7 @@
     let token = localStorage.getItem("access_token");
     let username = null;
     async function login() {
-      const user = document.getElementById("username").value.trim();
+      let user = document.getElementById("username").value.trim();
       const pass = document.getElementById("password").value.trim();
       document.getElementById("login-error").textContent = "";
 
@@ -145,6 +145,9 @@
         return;
       }
 
+      if(!user.endsWith("@kinbech.com")){
+        user = user + "@kinbech.com";
+      }
       const formData = new URLSearchParams();
       formData.append("username", user);
       formData.append("password", pass);
@@ -166,7 +169,7 @@
     }
 
     async function register() {
-      const username = document.getElementById("reg-username").value.trim();
+      let username = document.getElementById("reg-username").value.trim();
       const fullName = document.getElementById("reg-fullname").value.trim();
       const password = document.getElementById("reg-password").value.trim();
 
@@ -176,6 +179,10 @@
       if (!username || !password || !fullName) {
         document.getElementById("register-error").textContent = "All fields required.";
         return;
+      }
+
+      if(!username.endsWith("@kinbech.com")){
+        username = username + "@kinbech.com";
       }
 
       const payload = {


### PR DESCRIPTION
## Summary
- enforce `@kinbech.com` usernames during registration
- suggest an alternative if the username already exists
- auto-append the domain during login and registration on the frontend

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686e5c9dede0832fb0f507d20793b4a6