### PR TITLE
Fix admin redirect to dashboard

### DIFF
--- a/static/profile.html
+++ b/static/profile.html
@@ -154,7 +154,7 @@
                         }
                     });
             } else if (role === 'admin') {
-                window.location.href = "/static/admin.html";
+                window.location.href = "/static/admin_dashboard.html";
             }
         }
 


### PR DESCRIPTION
## Summary
- redirect admins from profile page to `/static/admin_dashboard.html`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e62fc2988832faa17390e85db53a4