### PR TITLE
Add order completion feature

### DIFF
--- a/static/admin_orders.html
+++ b/static/admin_orders.html
@@ -41,18 +41,35 @@
             orders.forEach(o => {
                 const div = document.createElement('div');
                 div.className = 'order';
+                const completeBtn = o.status === 'Fulfilled'
+                    ? `<button onclick="completeOrder(${o.id})">Mark Completed</button>`
+                    : '';
                 div.innerHTML = `
                     <strong>Buyer:</strong> ${o.buyer} ${o.phone_number ? '(' + o.phone_number + ')' : ''}<br>
                     Address: ${o.address}<br>
                     ${o.items.map(i => `${i.name} x${i.quantity} - ₹${(i.price * i.quantity).toFixed(2)}`).join('<br>')}<br>
                     <strong>Total: ₹${o.total.toFixed(2)}</strong><br>
                     Status: ${o.status}<br>
-                    Time: ${new Date(o.timestamp).toLocaleString()}
+                    Time: ${new Date(o.timestamp).toLocaleString()}<br>
+                    ${completeBtn}
                 `;
                 container.appendChild(div);
             });
         }
         loadOrders();
+
+        async function completeOrder(orderId) {
+            if (!confirm('Complete this order?')) return;
+            const res = await fetch(`/orders/${orderId}/complete`, {
+                method: 'POST',
+                headers: { Authorization: 'Bearer ' + token }
+            });
+            if (res.ok) {
+                loadOrders();
+            } else {
+                alert('Failed to complete order');
+            }
+        }
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `/orders/{order_id}/complete` API to allow admin or buyer to finalize orders
- update admin orders page with button to mark fulfilled orders as completed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e664b33d0832fb834d3dff00ebb67