### PR TITLE
Enable admin order fulfillment

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,15 @@ curl -H "Authorization: Bearer <token>" \
 Each seller object in the returned JSON also contains a `products` array listing all
 their items.
 
+Admins can mark any order as fulfilled, bypassing the seller ownership check:
+
+```bash
+curl -X POST -H "Authorization: Bearer <token>" \
+     http://127.0.0.1:8000/orders/<order_id>/fulfill
+```
+
+This endpoint is also used by the admin dashboard to update pending orders.
+
 ---
 
 ## Folder Info

--- a/static/admin_orders.html
+++ b/static/admin_orders.html
@@ -41,6 +41,9 @@
             orders.forEach(o => {
                 const div = document.createElement('div');
                 div.className = 'order';
+                const fulfillBtn = o.status === 'Pending'
+                    ? `<button onclick="fulfillOrder(${o.id})">Mark Fulfilled</button>`
+                    : '';
                 const completeBtn = o.status === 'Fulfilled'
                     ? `<button onclick="completeOrder(${o.id})">Mark Completed</button>`
                     : '';
@@ -51,7 +54,7 @@
                     <strong>Total: ₹${o.total.toFixed(2)}</strong><br>
                     Status: ${o.status}<br>
                     Time: ${new Date(o.timestamp).toLocaleString()}<br>
-                    ${completeBtn}
+                    ${fulfillBtn} ${completeBtn}
                 `;
                 container.appendChild(div);
             });
@@ -68,6 +71,19 @@
                 loadOrders();
             } else {
                 alert('Failed to complete order');
+            }
+        }
+
+        async function fulfillOrder(orderId) {
+            if (!confirm('Mark this order fulfilled?')) return;
+            const res = await fetch(`/orders/${orderId}/fulfill`, {
+                method: 'POST',
+                headers: { Authorization: 'Bearer ' + token }
+            });
+            if (res.ok) {
+                loadOrders();
+            } else {
+                alert('Failed to fulfill order');
             }
         }
     </script>


### PR DESCRIPTION
## Summary
- let admins bypass seller ownership when fulfilling orders
- expose `/orders/{order_id}/fulfill` route
- show *Mark Fulfilled* button on admin orders list
- document new admin ability

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_686e6f828f44832f8d739ec2add958c8