### PR TITLE
Fix quoting in buyers list

### DIFF
--- a/static/buyers.html
+++ b/static/buyers.html
@@ -154,13 +154,14 @@
 
                 products.forEach(p => {
                     const li = document.createElement("li");
+                    const nameEsc = p.name.replace(/'/g, "\\'");
                     li.innerHTML = `
   ${p.image_urls.map(url => `<img src="${url}" alt="${p.name}" width="150" height="150">`).join("")}<br/>
 
   <strong>${p.name}</strong> - ₹${p.price.toFixed(2)}<br/>
   ${p.description ? p.description + "<br/>" : ""}
-  <button onclick="buyProduct(${p.id}, '${p.name}', ${p.price}, '${p.image_urls[0] || ''}')">Buy</button>
-  <button onclick="addToCart(${p.id}, '${p.name}', ${p.price}, '${p.image_urls[0] || ''}')">Add to Cart</button>
+  <button onclick="buyProduct(${p.id}, '${nameEsc}', ${p.price}, '${p.image_urls[0] || ''}')">Buy</button>
+  <button onclick="addToCart(${p.id}, '${nameEsc}', ${p.price}, '${p.image_urls[0] || ''}')">Add to Cart</button>
 `;
 
                     li.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary
- escape single quotes in product names before inserting into onclick handlers
- verified escaped HTML with a Node snippet

## Testing
- `python -m py_compile main.py models.py schemas.py database.py`
- `node /tmp/test_page.js`


------
https://chatgpt.com/codex/tasks/task_e_686e7e721590832fa2ea97f642e667f3