### PR TITLE
Fix product name escaping in buyer page

### DIFF
--- a/static/buyers.html
+++ b/static/buyers.html
@@ -154,7 +154,12 @@
 
                 products.forEach(p => {
                     const li = document.createElement("li");
-                    const nameEsc = p.name.replace(/'/g, "\\'");
+                    // Escape both single quotes and backslashes so product
+                    // names with characters like \ or ' don't break the
+                    // onclick handler strings below
+                    const nameEsc = p.name
+                        .replace(/\\/g, "\\\\")
+                        .replace(/'/g, "\\'");
                     li.innerHTML = `
   ${p.image_urls.map(url => `<img src="${url}" alt="${p.name}" width="150" height="150">`).join("")}<br/>
 


### PR DESCRIPTION
## Summary
- escape backslashes in product names when rendering action buttons

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686e849b2628832fab632f96ec0782f4