### PR TITLE
Fix product name quoting

### DIFF
--- a/main.py
+++ b/main.py
@@ -321,10 +321,10 @@ async def create_product(
     for image in images:
         ext = Path(image.filename).suffix
         filename = f"{uuid4().hex}{ext}"
-        image_path = Path("static/uploads") / filename
+        image_path = Path("static", "uploads", filename)
         with open(image_path, "wb") as buffer:
             buffer.write(await image.read())
-        image_urls.append(f"/{image_path}")  # store with /static path
+        image_urls.append("/" + image_path.as_posix())  # use forward slashes
 
     new_product = DBProduct(  # ✅ correct model (SQLAlchemy)
         name=name,

--- a/static/buyers.html
+++ b/static/buyers.html
@@ -154,10 +154,12 @@
 
                 products.forEach(p => {
                     const li = document.createElement("li");
-                    // Escape both single quotes and backslashes so product
-                    // names with characters like \ or ' don't break the
-                    // onclick handler strings below
+                    // Escape product name and image URL for use inside onclick strings
                     const nameEsc = p.name
+                        .replace(/\\/g, "\\\\")
+                        .replace(/'/g, "\\'");
+                    const firstImage = p.image_urls[0] || "";
+                    const imageEsc = firstImage
                         .replace(/\\/g, "\\\\")
                         .replace(/'/g, "\\'");
                     li.innerHTML = `
@@ -165,8 +167,8 @@
 
   <strong>${p.name}</strong> - ₹${p.price.toFixed(2)}<br/>
   ${p.description ? p.description + "<br/>" : ""}
-  <button onclick="buyProduct(${p.id}, '${nameEsc}', ${p.price}, '${p.image_urls[0] || ''}')">Buy</button>
-  <button onclick="addToCart(${p.id}, '${nameEsc}', ${p.price}, '${p.image_urls[0] || ''}')">Add to Cart</button>
+  <button onclick="buyProduct(${p.id}, '${nameEsc}', ${p.price}, '${imageEsc}')">Buy</button>
+  <button onclick="addToCart(${p.id}, '${nameEsc}', ${p.price}, '${imageEsc}')">Add to Cart</button>
 `;
 
                     li.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary
- escape product names and image URLs so onclick handlers work for special characters
- normalize uploaded image paths to forward slashes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e8abbee7c832fa87c4585550275f0