### PR TITLE
Add shipping note for buyers

### DIFF
--- a/static/cart.html
+++ b/static/cart.html
@@ -76,6 +76,9 @@
         <tbody></tbody>
     </table>
     <p id="total"></p>
+    <p id="shipping-note" style="font-style: italic; color: #555;">
+        Note: Shipping charge will be added based on the distance covered by the delivery boy.
+    </p>
     <input type="text" id="address-line1" placeholder="Address Line 1" />
     <input type="text" id="address-line2" placeholder="Address Line 2 (optional)" />
     <input type="text" id="phone-number" placeholder="Phone Number" />


### PR DESCRIPTION
## Summary
- add explanatory note on cart page about distance-based shipping charge

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68702dcb5eec832f89132914cfdc116a