### PR TITLE
Track shop names in order items

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - Admin dashboard to validate or remove products and view all sellers
 - Buyers can place orders and receive notifications when orders are fulfilled
 - Optional shop name, address and phone number for each seller
+- Order items now store the seller's shop name
 - Background task removes products after their expiry date
 - Basic forgot‑password endpoint (placeholder for WhatsApp integration)
 - Clean HTML/CSS frontend

--- a/models.py
+++ b/models.py
@@ -52,6 +52,7 @@ class OrderItem(Base):
     id = Column(Integer, primary_key=True)
     order_id = Column(Integer, ForeignKey("orders.id"))
     product_id = Column(Integer, ForeignKey("products.id"))
+    shop_name = Column(String)
     quantity = Column(Integer)
     order = relationship("Order", back_populates="items")
     product = relationship("Product")

--- a/static/admin_orders.html
+++ b/static/admin_orders.html
@@ -54,7 +54,7 @@
                 div.innerHTML = `
                     <strong>Buyer:</strong> ${o.buyer} ${o.phone_number ? '(' + o.phone_number + ')' : ''}<br>
                     Address: ${o.address}<br>
-                    ${o.items.map(i => `${i.name} x${i.quantity} - ₹${(i.price * i.quantity).toFixed(2)}`).join('<br>')}<br>
+                    ${o.items.map(i => `${i.shop_name ? i.shop_name + ': ' : ''}${i.name} x${i.quantity} - ₹${(i.price * i.quantity).toFixed(2)}`).join('<br>')}<br>
                     <strong>Total: ₹${o.total.toFixed(2)}</strong><br>
                     Status: ${o.status}<br>
                     Time: ${new Date(o.timestamp).toLocaleString()}<br>

--- a/static/buyer_orders.html
+++ b/static/buyer_orders.html
@@ -46,7 +46,7 @@
                     : '';
                 div.innerHTML = `
                     Address: ${o.address}<br>
-                    ${o.items.map(i => `${i.name} x${i.quantity} - ₹${(i.price * i.quantity).toFixed(2)}`).join('<br>')}<br>
+                    ${o.items.map(i => `${i.shop_name ? i.shop_name + ': ' : ''}${i.name} x${i.quantity} - ₹${(i.price * i.quantity).toFixed(2)}`).join('<br>')}<br>
                     <strong>Total: ₹${o.total.toFixed(2)}</strong><br>
                     Status: ${o.status}<br>
                     Time: ${new Date(o.timestamp).toLocaleString()}<br>

--- a/static/orders.html
+++ b/static/orders.html
@@ -62,7 +62,7 @@
             <h3>Order #${order.id} - Buyer: ${order.buyer}</h3>
             <div class="items">
               ${order.items.map(item => `
-                ${item.name} x${item.quantity} - ₹${(item.price * item.quantity).toFixed(2)}<br/>
+                ${item.shop_name ? item.shop_name + ' - ' : ''}${item.name} x${item.quantity} - ₹${(item.price * item.quantity).toFixed(2)}<br/>
               `).join("")}
               Address: ${order.address}<br/>
               <strong>Total: ₹${order.total.toFixed(2)}</strong><br/>


### PR DESCRIPTION
## Summary
- add `shop_name` column to `OrderItem`
- record `product.shop_name` when creating order items
- expose `shop_name` in buyer, seller and admin order APIs
- show shop names on HTML order pages
- document new behavior in README

## Testing
- `python -m py_compile main.py models.py database.py`

------
https://chatgpt.com/codex/tasks/task_e_687037877c08832f8fad4f7f976e4d2e