### PR TITLE
Use SECRET_KEY env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,17 @@
    ```bash
    pip install -r requirements.txt
    ```
+4. **Set `SECRET_KEY` environment variable**
+   ```bash
+   export SECRET_KEY="your-secret-key"
+   ```
 
-4. **Run the app**
+5. **Run the app**
    ```bash
    uvicorn main:app --reload
    ```
 
-5. Open your browser and go to:
+6. Open your browser and go to:
    [http://127.0.0.1:8000](http://127.0.0.1:8000)
 
    Registration is handled directly on this page; there is no separate

--- a/main.py
+++ b/main.py
@@ -71,7 +71,8 @@ async def root():
 
 
 # JWT settings
-SECRET_KEY = "secretkey"
+# Read secret key from environment variable for security
+SECRET_KEY = os.getenv("SECRET_KEY", "secretkey")
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 60
 


### PR DESCRIPTION
## Summary
- load SECRET_KEY from the environment instead of hardcoding
- document the environment variable in the README

## Testing
- `python -m py_compile main.py models.py database.py schemas.py`

------
https://chatgpt.com/codex/tasks/task_e_6870b5151588832faea2f844d292d411