### PR TITLE
Restrict admin register page

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ These values appear on the seller dashboard where they can be edited anytime.
 
 ## Admin Users
 
-Create an admin account by sending a role of `"admin"` when registering or by visiting the browser based form at `/admin/register`:
+Create an admin account by sending a role of `"admin"` when registering.  Existing admins can also use the form at `/admin/register`, which now requires admin login:
 
 ```bash
 curl -X POST -H "Content-Type: application/json" \

--- a/main.py
+++ b/main.py
@@ -935,6 +935,9 @@ async def admin_sellers_page():
 
 
 @app.get("/admin/register", include_in_schema=False)
-async def admin_register_page():
-    """Serve the admin registration form."""
+async def admin_register_page(
+    current_user: dict = Depends(get_current_user_from_token),
+):
+    """Serve the admin registration form for logged-in admins only."""
+    require_admin(current_user)
     return FileResponse("static/admin_register.html")


### PR DESCRIPTION
## Summary
- lock down `/admin/register` so only authenticated admins can view the page
- document that the admin registration form requires admin login

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68714dcd0164832fa79a263e52acb77b