### PR TITLE
Add restricted admin register route

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ These values appear on the seller dashboard where they can be edited anytime.
 
 ## Admin Users
 
-Create an admin account by sending a role of `"admin"` when registering.  Existing admins can also use the form at `/admin/register`, which now requires admin login:
+Create an admin account by sending a role of `"admin"` when registering.  Existing admins can also use the form at `/admin/register`, which now requires admin login. The admin registration page itself is only accessible to the special account `safal@kinbech.shop`:
 
 ```bash
 curl -X POST -H "Content-Type: application/json" \

--- a/main.py
+++ b/main.py
@@ -36,7 +36,6 @@ from uuid import uuid4
 from pathlib import Path
 
 app = FastAPI()
-app.mount("/static", StaticFiles(directory="static"), name="static")
 Base.metadata.create_all(bind=engine)
 
 
@@ -177,6 +176,17 @@ def get_current_user_from_token(
         }
     except JWTError:
         raise HTTPException(status_code=401, detail="Invalid token")
+
+
+@app.get("/static/admin_register.html", include_in_schema=False)
+async def restricted_admin_register(
+    current_user: dict = Depends(get_current_user_from_token),
+):
+    if current_user["username"] != "safal@kinbech.shop":
+        raise HTTPException(status_code=403, detail="Access denied")
+    return FileResponse("static/admin_register.html")
+
+app.mount("/static", StaticFiles(directory="static"), name="static")
 
 
 def _generate_unique_username(base: str, db: Session) -> str:


### PR DESCRIPTION
## Summary
- restrict direct access to `static/admin_register.html` so only `safal@kinbech.shop` can view it
- mount static files after the new restriction to give the route precedence
- clarify in README that the admin registration page is limited to this account

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6871844e7f44832f80c84040da7e9bee