### PR TITLE
Update README with Python compatibility notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@
 
 ## Technology Used
 
-- Python (FastAPI)
+- Python 3.11 (FastAPI)
 - HTML, CSS, JavaScript (frontend)
 - SQLite (database)
 - JWT Token for login
 - Uvicorn to run the app
+
+This project is tested with **Python 3.11**.
 
 ---
 
@@ -46,6 +48,12 @@
 3. **Install required packages**
    ```bash
    pip install -r requirements.txt
+   ```
+   # Using Python 3.13?
+   psycopg2-binary does not yet publish wheels for 3.13.
+   Install `psycopg2` from source instead:
+   ```bash
+   pip install psycopg2 --no-binary psycopg2
    ```
 4. **Set `SECRET_KEY` environment variable**
    ```bash


### PR DESCRIPTION
## Summary
- document that the project is tested with Python 3.11
- add note about installing psycopg2 from source when using Python 3.13

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687196d0ea68832f81352d573f6602f0