### PR TITLE
Handle psycopg2 install for Python 3.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,8 @@ This project is tested with **Python 3.11**.
    ```bash
    pip install -r requirements.txt
    ```
-   # Using Python 3.13?
-   psycopg2-binary does not yet publish wheels for 3.13.
-   Install `psycopg2` from source instead:
-   ```bash
-   pip install psycopg2 --no-binary psycopg2
-   ```
+   The requirements file automatically installs `psycopg2` on Python 3.13+
+   and `psycopg2-binary` otherwise.
 4. **Set `SECRET_KEY` environment variable**
    ```bash
    export SECRET_KEY="your-secret-key"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-﻿annotated-types==0.7.0
+annotated-types==0.7.0
 anyio==4.9.0
 bcrypt==3.2.2
 click==8.2.1
@@ -24,6 +24,7 @@ starlette==0.46.2
 typing-inspection==0.4.1
 typing_extensions==4.14.0
 uvicorn==0.35.0
-psycopg2-binary==2.9.9
+psycopg2-binary==2.9.9; python_version < "3.13"
+psycopg2==2.9.9; python_version >= "3.13"
 twilio==9.0.4
 


### PR DESCRIPTION
## Summary
- add environment markers in `requirements.txt` to use `psycopg2` on Python 3.13 and later
- update README instructions to mention the automatic handling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871995433ec832fb0b711ad7628aa32