### PR TITLE
Fix psycopg2 import error for Python 3.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ This project is tested with **Python 3.11**.
    ```bash
    pip install -r requirements.txt
    ```
-   The requirements file automatically installs `psycopg2` on Python 3.13+
-   and `psycopg2-binary` otherwise.
+   The requirements file installs `psycopg2-binary`, which works across
+   Python versions including 3.13.
 4. **Set `SECRET_KEY` environment variable**
    ```bash
    export SECRET_KEY="your-secret-key"

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,6 @@ starlette==0.46.2
 typing-inspection==0.4.1
 typing_extensions==4.14.0
 uvicorn==0.35.0
-psycopg2==2.9.9; python_version >= "3.13"
+psycopg2-binary==2.9.9
 twilio==9.0.4
 


### PR DESCRIPTION
## Summary
- use `psycopg2-binary` to avoid missing symbol errors on Python 3.13
- update documentation to reflect the new dependency

## Testing
- `python -m py_compile database.py main.py models.py schemas.py`

------
https://chatgpt.com/codex/tasks/task_e_68719c9fd100832fb311361cb18540f1