### PR TITLE
Expose static directory

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,6 +45,9 @@ from twilio.rest import Client
 
 app = FastAPI()
 
+# Expose all files in the ./static directory
+app.mount("/static", StaticFiles(directory="static"), name="static")
+
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- mount the `static` folder so all files under it are served

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687254ac46ec832fa40a15015a2cc63a