### PR TITLE
Add buyer view link and cleanup logout

### DIFF
--- a/static/buyers.html
+++ b/static/buyers.html
@@ -115,10 +115,6 @@
         <button onclick="window.location.href='/static/cart.html'">Go to Cart</button>
         <button onclick="window.location.href='/static/buyer_orders.html'">My Orders</button>
 
-        <button onclick="logout()"
-            style="background-color: red; color: white; border: none; padding: 8px 16px; border-radius: 5px; cursor: pointer;">
-            Logout
-        </button>
     </div>
 
     <!-- Modal for viewing product details -->

--- a/static/index.html
+++ b/static/index.html
@@ -130,7 +130,8 @@
     <img src="static/Kinbechlogo.jpg" alt="Kinbech Logo" class="logo" />
  <h3 class="about-title">About KinBech</h3>
     <p class="about-text">KinBech connects local buyers and sellers.</p>
-    <p class="about-text">Sellers can list products with images and prices. Buyers browse items, add them to the cart, and place orders.</p>  <button onclick="window.location.href='static/shop_register.html'">Start Selling</button>
+<p class="about-text">Sellers can list products with images and prices. Buyers browse items, add them to the cart, and place orders.</p>  <button onclick="window.location.href='static/shop_register.html'">Start Selling</button>
+  <button onclick="window.location.href='static/buyers.html'">Start Buying</button>
   
 
   </div>


### PR DESCRIPTION
## Summary
- add "Start Buying" button on the home page linking to the buyer view
- remove the logout button from the buyer view page

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6873ee578da8832f8dd5b601db519510