### PR TITLE
Add shop registration table and endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -32,6 +32,7 @@ from models import (
     UserModel as DBUser,
     Product as DBProduct,
     ResetToken,
+    Shop,
 )
 from database import engine, get_db, SessionLocal
 from schemas import ProductOut
@@ -410,6 +411,23 @@ def update_seller_details(
     user.phone_number = phone_number
     db.commit()
     return {"address": user.address, "phone_number": user.phone_number}
+
+
+@app.post("/shops")
+def create_shop(
+    shop_name: str = Form(...),
+    address: str = Form(...),
+    phone_number: str = Form(...),
+    current_user: dict = Depends(get_current_user_from_token),
+    db: Session = Depends(get_db),
+):
+    if db.query(Shop).filter(Shop.phone_number == phone_number).first():
+        raise HTTPException(status_code=400, detail="Phone number already registered")
+
+    shop = Shop(phone_number=phone_number, shop_name=shop_name, address=address)
+    db.add(shop)
+    db.commit()
+    return {"msg": "Shop registered"}
 
 
 @app.post("/products")

--- a/models.py
+++ b/models.py
@@ -68,3 +68,13 @@ class ResetToken(Base):
     expires_at = Column(DateTime)
 
     user = relationship("UserModel")
+
+
+class Shop(Base):
+    """Stores registered shop details."""
+
+    __tablename__ = "shops"
+
+    phone_number = Column(String, primary_key=True)
+    shop_name = Column(String)
+    address = Column(String)

--- a/static/shop_register.html
+++ b/static/shop_register.html
@@ -86,6 +86,16 @@
                 body: form2
             });
 
+            const form3 = new FormData();
+            form3.append('shop_name', name);
+            form3.append('address', address);
+            form3.append('phone_number', phone);
+            await fetch('/shops', {
+                method: 'POST',
+                headers: { Authorization: 'Bearer ' + token },
+                body: form3
+            });
+
             window.location.href = '/static/sellers.html';
         }
     </script>


### PR DESCRIPTION
## Summary
- create a `Shop` model for storing shop name, address and phone number
- import `Shop` in `main.py`
- add `/shops` endpoint to persist registered shops
- update `shop_register.html` to send form data to `/shops`

## Testing
- `python -m py_compile main.py models.py database.py schemas.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687426073300832f9964b8b196bc2ab7