### PR TITLE
Add nav buttons to shop registration page

### DIFF
--- a/static/shop_register.html
+++ b/static/shop_register.html
@@ -44,6 +44,10 @@
     <button onclick="saveShop()">Save</button>
     <p id="msg"></p>
 
+    <p style="margin-top:20px;">Already registered?</p>
+    <button onclick="goToAdd()">Add Products</button>
+    <button onclick="goToMyProducts()">View My Products</button>
+
     <script>
         const token = localStorage.getItem('access_token');
         if (!token) {
@@ -87,6 +91,14 @@
             });
 
             window.location.href = '/static/sellers.html';
+        }
+
+        function goToAdd() {
+            window.location.href = '/static/sellers.html';
+        }
+
+        function goToMyProducts() {
+            window.location.href = '/my-products';
         }
     </script>
 </body>


### PR DESCRIPTION
## Summary
- add quick navigation links for sellers on `shop_register.html`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68742876be8c832faa5ece13cce134fe