### PR TITLE
Ensure shop registry table exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,21 @@ curl -X POST \
 
 These values appear on the seller dashboard where they can be edited anytime.
 
+### Registering Your Shop
+
+Shop information is also stored in a dedicated `shops` table. Submit the shop
+name, address and phone number to `/shops`. The table is created automatically
+if it doesn't already exist and uses the phone number as the primary key.
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer <token>" \
+  -F shop_name="MyStore" \
+  -F address="123 Market St" \
+  -F phone_number="9876543210" \
+  http://127.0.0.1:8000/shops
+```
+
 ---
 
 ## Admin Users

--- a/main.py
+++ b/main.py
@@ -421,6 +421,9 @@ def create_shop(
     current_user: dict = Depends(get_current_user_from_token),
     db: Session = Depends(get_db),
 ):
+    # Ensure the shops table exists before inserting
+    Shop.__table__.create(bind=engine, checkfirst=True)
+
     if db.query(Shop).filter(Shop.phone_number == phone_number).first():
         raise HTTPException(status_code=400, detail="Phone number already registered")
 


### PR DESCRIPTION
## Summary
- create shops table if missing when registering a shop
- document `/shops` endpoint in README

## Testing
- `python -m py_compile main.py models.py database.py`

------
https://chatgpt.com/codex/tasks/task_e_68742e21a588832fb402b0793765992d