### PR TITLE
Remove token requirement for registering shop

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ if it doesn't already exist and uses the phone number as the primary key.
 
 ```bash
 curl -X POST \
-  -H "Authorization: Bearer <token>" \
   -F shop_name="MyStore" \
   -F address="123 Market St" \
   -F phone_number="9876543210" \

--- a/main.py
+++ b/main.py
@@ -418,7 +418,6 @@ def create_shop(
     shop_name: str = Form(...),
     address: str = Form(...),
     phone_number: str = Form(...),
-    current_user: dict = Depends(get_current_user_from_token),
     db: Session = Depends(get_db),
 ):
     # Ensure the shops table exists before inserting

--- a/static/shop_register.html
+++ b/static/shop_register.html
@@ -51,9 +51,6 @@
 
     <script>
         const token = localStorage.getItem('access_token');
-        if (!token) {
-            window.location.href = '/static/index.html';
-        }
 
         async function saveShop() {
             const name = document.getElementById('shop-name').value.trim();
@@ -68,28 +65,25 @@
                 return;
             }
 
-            const form = new FormData();
-            form.append('name', name);
-            let res = await fetch('/shop/name', {
-                method: 'POST',
-                headers: { Authorization: 'Bearer ' + token },
-                body: form
-            });
-            if (!res.ok) {
-                const err = await res.json();
-                msg.textContent = err.detail || 'Error';
-                msg.style.color = 'red';
-                return;
+            if (token) {
+                const form = new FormData();
+                form.append('name', name);
+                let res = await fetch('/shop/name', {
+                    method: 'POST',
+                    headers: { Authorization: 'Bearer ' + token },
+                    body: form
+                });
+                if (res.ok) {
+                    const form2 = new FormData();
+                    form2.append('address', address);
+                    form2.append('phone_number', phone);
+                    await fetch('/seller/details', {
+                        method: 'POST',
+                        headers: { Authorization: 'Bearer ' + token },
+                        body: form2
+                    });
+                }
             }
-
-            const form2 = new FormData();
-            form2.append('address', address);
-            form2.append('phone_number', phone);
-            await fetch('/seller/details', {
-                method: 'POST',
-                headers: { Authorization: 'Bearer ' + token },
-                body: form2
-            });
 
             const form3 = new FormData();
             form3.append('shop_name', name);
@@ -97,11 +91,10 @@
             form3.append('phone_number', phone);
             await fetch('/shops', {
                 method: 'POST',
-                headers: { Authorization: 'Bearer ' + token },
                 body: form3
             });
 
-            window.location.href = '/static/sellers.html';
+            window.location.href = token ? '/static/sellers.html' : '/static/index.html';
         }
 
         function goToAdd() {


### PR DESCRIPTION
## Summary
- allow `/shops` endpoint to be called without authentication
- update shop registration page so it works when not logged in
- adjust documentation for registering a shop

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6874370e7198832f867ff4c04713ce40