### PR TITLE
Improve shop registration flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,9 @@ These values appear on the seller dashboard where they can be edited anytime.
 
 ### Registering Your Shop
 
-Shop information is also stored in a dedicated `shops` table. Submit the shop
-name, address and phone number to `/shops`. The table is created automatically
-if it doesn't already exist and uses the phone number as the primary key.
+Shop information is stored in a dedicated `shop` table. Submit the shop name,
+address and phone number to `/shops`. The table is created automatically if it
+doesn't already exist and uses the phone number as the primary key.
 
 ```bash
 curl -X POST \

--- a/main.py
+++ b/main.py
@@ -420,7 +420,7 @@ def create_shop(
     phone_number: str = Form(...),
     db: Session = Depends(get_db),
 ):
-    # Ensure the shops table exists before inserting
+    # Ensure the shop table exists before inserting
     Shop.__table__.create(bind=engine, checkfirst=True)
 
     if db.query(Shop).filter(Shop.phone_number == phone_number).first():

--- a/models.py
+++ b/models.py
@@ -73,7 +73,8 @@ class ResetToken(Base):
 class Shop(Base):
     """Stores registered shop details."""
 
-    __tablename__ = "shops"
+    # Use a singular table name for clarity
+    __tablename__ = "shop"
 
     phone_number = Column(String, primary_key=True)
     shop_name = Column(String)

--- a/static/shop_register.html
+++ b/static/shop_register.html
@@ -91,12 +91,23 @@
             form3.append('shop_name', name);
             form3.append('address', address);
             form3.append('phone_number', phone);
-            await fetch('/shops', {
-                method: 'POST',
-                body: form3
-            });
-
-            window.location.href = token ? '/static/sellers.html' : '/static/index.html';
+            try {
+                const res = await fetch('/shops', {
+                    method: 'POST',
+                    body: form3
+                });
+                const data = await res.json().catch(() => ({}));
+                if (res.ok) {
+                    msg.textContent = data.msg || 'Shop registered!';
+                    msg.style.color = 'green';
+                } else {
+                    msg.textContent = data.detail || 'Registration failed';
+                    msg.style.color = 'red';
+                }
+            } catch (err) {
+                msg.textContent = 'Registration failed';
+                msg.style.color = 'red';
+            }
         }
 
         function goToAdd() {


### PR DESCRIPTION
## Summary
- keep user on the shop registration page and show result message
- use singular `shop` table name with phone number as primary key
- update README documentation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68743e41b52c832f9f12dffdd0ccb59f