### PR TITLE
Update price field validation

### DIFF
--- a/static/sellers.html
+++ b/static/sellers.html
@@ -76,7 +76,13 @@
     <p id="seller-msg" style="color:green;"></p>
     <input type="text" id="product-name" placeholder="Product Name" />
     <input type="text" id="product-desc" placeholder="Description (optional)" />
-    <input type="number" id="product-price" placeholder="Price" step="0.01" />
+    <input
+        type="text"
+        id="product-price"
+        placeholder="000-000"
+        pattern="^(?:2(?:0[4-9]|[1-9][0-9])|[3-5][0-9]{2})-[0-9]{3}$"
+        title="Enter price in 000-000 format (204-000 to 599-999)"
+    />
     <input type="number" id="product-range" placeholder="Delivery Range (km)" />
     <input type="text" id="seller-phone" placeholder="Registered Phone Number" />
     <input type="file" id="product-image" accept="image/*" multiple>


### PR DESCRIPTION
## Summary
- enforce 000-000 price format and restrict range from 204-000 to 599-999 on seller page

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6874f577997c832fbcdc2e3aaf53cbfb