### PR TITLE
Fix seller product add flow and preview

### DIFF
--- a/static/sellers.html
+++ b/static/sellers.html
@@ -83,6 +83,19 @@
 
     <button class="primary-button" onclick="addProduct()">Add Product</button>
 
+    <!-- Preview table for newly added products -->
+    <table id="added-products" style="width:100%; margin-top:20px; border-collapse: collapse;">
+        <thead>
+            <tr>
+                <th>Image</th>
+                <th>Name</th>
+                <th>Price</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+
 
     <script>
         const token = localStorage.getItem("access_token");
@@ -143,6 +156,7 @@
             formData.append("shop_name", shopName);
             formData.append("description", desc);
             formData.append("price", price);
+            formData.append("delivery_range_km", range);
             for (let i = 0; i < imageInput.files.length; i++) {
                 formData.append("images", imageInput.files[i]);
             }
@@ -163,6 +177,16 @@
                 document.getElementById("seller-msg").style.color = "green";
                 document.getElementById("seller-msg").textContent = "Product added successfully!";
 
+                // Show one-time preview in the table
+                const tbody = document.getElementById("added-products").querySelector("tbody");
+                const row = document.createElement("tr");
+                const imgCell = document.createElement("td");
+                const url = URL.createObjectURL(imageInput.files[0]);
+                imgCell.innerHTML = `<img src="${url}" alt="${name}" width="60">`;
+                row.appendChild(imgCell);
+                row.innerHTML += `<td>${name}</td><td>${price}</td><td>${desc}</td>`;
+                tbody.appendChild(row);
+
                 // Clear inputs
                 document.getElementById("product-name").value = "";
                 document.getElementById("product-desc").value = "";
@@ -177,8 +201,7 @@
             }
         }
 
-        
-
+        window.addEventListener('DOMContentLoaded', loadShopInfo);
     </script>
 
 </body>


### PR DESCRIPTION
## Summary
- fix shop validation on seller page by loading shop info on page load
- show a one-time preview of newly added products in a table

## Testing
- `python -m py_compile main.py models.py schemas.py database.py`

------
https://chatgpt.com/codex/tasks/task_e_6874f73b1a40832f9a0b6d9392bf1835