### PR TITLE
Add added_products log and phone validation

### DIFF
--- a/models.py
+++ b/models.py
@@ -81,3 +81,16 @@ class Shop(Base):
     __table_args__ = (
         UniqueConstraint('phone_number', name='uix_phone_number'),
     )
+
+
+class AddedProduct(Base):
+    """Log of all added products with minimal details."""
+
+    __tablename__ = "added_products"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    product_name = Column(String, nullable=False)
+    details = Column(String, nullable=True)
+
+    user = relationship("UserModel")

--- a/static/sellers.html
+++ b/static/sellers.html
@@ -164,6 +164,7 @@
             formData.append("description", desc);
             formData.append("price", price);
             formData.append("delivery_range_km", range);
+            formData.append("phone_number", phone);
             for (let i = 0; i < imageInput.files.length; i++) {
                 formData.append("images", imageInput.files[i]);
             }


### PR DESCRIPTION
## Summary
- track product additions in new `added_products` table
- require sellers to provide their registered phone number when posting a product
- log each added product with minimal details
- update seller dashboard form to send phone number

## Testing
- `python -m py_compile main.py models.py schemas.py`

------
https://chatgpt.com/codex/tasks/task_e_6874fc8fecbc832f8a42c65e989ad037