### PR TITLE
Fix one-time admin registration page

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,14 @@ curl -X POST \
 
 ## Admin Users
 
+One-time admin setup is provided at `/admin/phone-register`. It only asks for a phone number and automatically creates the first admin. After registration you are logged in and forwarded to the admin dashboard. You can also call this endpoint directly with JSON:
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+     -d '{"phone_number": "9876543210"}' \
+     http://127.0.0.1:8000/admin/phone-register
+```
+
 Create an admin account by sending a role of `"admin"` when registering.  Existing admins can also use the form at `/admin/register`, which is publicly accessible (no login required):
 
 ```bash

--- a/main.py
+++ b/main.py
@@ -1102,3 +1102,40 @@ async def admin_sellers_page():
 async def admin_register_page():
     """Serve the admin registration form."""
     return FileResponse("static/admin_register.html")
+
+
+# One-time admin phone registration page
+@app.get("/admin/phone-register", include_in_schema=False)
+async def admin_phone_register_page():
+    """Serve the phone based admin registration page."""
+    return FileResponse("static/admin_phone_register.html")
+
+
+@app.post("/admin/phone-register", include_in_schema=False)
+async def admin_phone_register(
+    phone_number: str = Body(..., embed=True), db: Session = Depends(get_db)
+):
+    """Register a new admin using only a phone number once."""
+    # If any admin already exists, block new registrations
+    existing_admin = db.query(DBUser).filter(DBUser.role.like("%admin%"))
+    if existing_admin.first():
+        raise HTTPException(status_code=400, detail="Admin already registered")
+
+    username = f"{phone_number}@{USERNAME_DOMAIN}"
+    if db.query(DBUser).filter(DBUser.username == username).first():
+        raise HTTPException(status_code=400, detail="Phone already registered")
+
+    random_password = uuid4().hex
+    db_user = DBUser(
+        username=username,
+        full_name="Admin",
+        hashed_password=get_password_hash(random_password),
+        role="admin",
+        phone_number=phone_number,
+    )
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+
+    token = create_access_token(data={"sub": db_user.username})
+    return {"access_token": token}

--- a/static/admin_phone_register.html
+++ b/static/admin_phone_register.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Admin Phone Registration</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 400px;
+            margin: 40px auto;
+            padding: 20px;
+            border: 1px solid #ddd;
+            border-radius: 10px;
+        }
+        input {
+            width: 100%;
+            padding: 8px;
+            margin: 6px 0;
+            box-sizing: border-box;
+        }
+        button {
+            padding: 10px 16px;
+            background-color: #007bff;
+            color: white;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
+        }
+        button:hover {
+            background-color: #0056b3;
+        }
+        #msg {
+            margin-top: 10px;
+            font-weight: bold;
+        }
+    </style>
+</head>
+<body>
+    <h2>One-Time Admin Registration</h2>
+    <input type="text" id="phone" placeholder="Phone Number" />
+    <button onclick="registerAdminPhone()">Register</button>
+    <p id="msg"></p>
+    <p><a href="/static/index.html">Back to Home</a></p>
+
+    <script>
+        async function registerAdminPhone() {
+            const phone = document.getElementById('phone').value.trim();
+            if (!phone) {
+                document.getElementById('msg').textContent = 'Enter phone number';
+                document.getElementById('msg').style.color = 'red';
+                return;
+            }
+            document.getElementById('msg').textContent = '';
+            const res = await fetch('/admin/phone-register', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ phone_number: phone })
+            });
+            const data = await res.json();
+            if (res.ok) {
+                localStorage.setItem('access_token', data.access_token);
+                window.location.href = '/static/admin_dashboard.html';
+            } else {
+                let msg = data.detail;
+                if (Array.isArray(msg)) {
+                    msg = msg[0]?.msg;
+                }
+                document.getElementById('msg').textContent = msg || 'Error';
+                document.getElementById('msg').style.color = 'red';
+            }
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- parse phone_number from JSON when registering the one-time admin
- improve error handling on the phone registration page
- document how to call `/admin/phone-register` directly

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6874fe1733b0832f9ed9b67e59562101