### PR TITLE
Implement phone verification popup and display extra product info

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -188,7 +188,10 @@
         const li = document.createElement("li");
         li.innerHTML = `
           ${p.image_urls.map(url => `<img src="${url}" alt="${p.name}" width="100" height="100">`).join("")}<br/>
-          <strong>${p.name}</strong> - ₹${p.price.toFixed(2)}
+          <strong>${p.name}</strong><br/>
+          ${p.description ? `<span>${p.description}</span><br/>` : ""}
+          ₹${p.price.toFixed(2)}<br/>
+          Delivery Range: ${p.delivery_range_km} km
         `;
         list.appendChild(li);
       });

--- a/static/sellers.html
+++ b/static/sellers.html
@@ -129,7 +129,6 @@
             if (resPhone.ok) {
                 const data = await resPhone.json();
                 registeredPhone = data.phone_number || "";
-                document.getElementById("seller-phone").value = registeredPhone;
             }
 
 
@@ -141,8 +140,9 @@
             const desc = document.getElementById("product-desc").value.trim();
             const price = parseFloat(document.getElementById("product-price").value);
             const range = parseInt(document.getElementById("product-range").value);
-            const phone = document.getElementById("seller-phone").value.trim();
             const imageInput = document.getElementById("product-image");
+
+            const phone = prompt("Enter your shop phone number to verify:") || "";
 
             if (!name || isNaN(price) || !imageInput.files.length) {
                 document.getElementById("seller-msg").style.color = "red";
@@ -200,8 +200,8 @@
                 document.getElementById("product-price").value = "";
                 document.getElementById("product-range").value = "";
                 document.getElementById("product-image").value = "";
-                // Stay on this page so the seller can add more products
-                // without being redirected back to the shop registration page
+                // Redirect to home page to see the product under the Products section
+                window.location.href = '/static/index.html';
             } catch (err) {
                 document.getElementById("seller-msg").style.color = "red";
                 document.getElementById("seller-msg").textContent = err.message;


### PR DESCRIPTION
## Summary
- prompt for phone number when adding a product
- redirect to homepage after successful add
- show description and delivery range on index

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687518cd7244832f92ffe0bcff6d2222