### PR TITLE
Fix seller product POST URL

### DIFF
--- a/static/sellers.html
+++ b/static/sellers.html
@@ -188,7 +188,7 @@
             }
 
             try {
-                const res = await fetch("/added_products", {
+                const res = await fetch("/products", {
                     method: "POST",
                     headers: { Authorization: "Bearer " + token },
                     body: formData


### PR DESCRIPTION
## Summary
- fix fetch() URL in seller page to call `/products`

## Testing
- `python -m py_compile main.py`
- `uvicorn main:app --port 8000 --log-level warning` *(fails: ModuleNotFoundError: No module named 'passlib')*

------
https://chatgpt.com/codex/tasks/task_e_68752f386fbc832f9c93bca84bde88ac