### PR TITLE
Add admin login by phone

### DIFF
--- a/main.py
+++ b/main.py
@@ -1167,3 +1167,27 @@ async def admin_phone_register(
 
     token = create_access_token(data={"sub": db_user.username})
     return {"access_token": token}
+
+
+# Admin login by phone number
+@app.get("/admin/login", include_in_schema=False)
+async def admin_login_page():
+    """Serve the admin login page."""
+    return FileResponse("static/admin_login.html")
+
+
+@app.post("/admin/login", include_in_schema=False)
+async def admin_login(
+    phone_number: str = Body(..., embed=True), db: Session = Depends(get_db)
+):
+    """Login an existing admin using phone number only."""
+    admin = (
+        db.query(DBUser)
+        .filter(DBUser.role.like("%admin%"), DBUser.phone_number == phone_number)
+        .first()
+    )
+    if not admin:
+        raise HTTPException(status_code=400, detail="Invalid phone number")
+
+    token = create_access_token(data={"sub": admin.username})
+    return {"access_token": token}

--- a/static/admin_login.html
+++ b/static/admin_login.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Admin Login</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 400px;
+            margin: 40px auto;
+            padding: 20px;
+            border: 1px solid #ddd;
+            border-radius: 10px;
+        }
+        input {
+            width: 100%;
+            padding: 8px;
+            margin: 6px 0;
+            box-sizing: border-box;
+        }
+        button {
+            padding: 10px 16px;
+            background-color: #007bff;
+            color: white;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
+        }
+        button:hover {
+            background-color: #0056b3;
+        }
+        #msg {
+            margin-top: 10px;
+            font-weight: bold;
+        }
+    </style>
+</head>
+<body>
+    <h2>Admin Login</h2>
+    <p>This page is restricted. Admins only.</p>
+    <input type="text" id="phone" placeholder="Admin Phone Number" />
+    <button onclick="loginAdmin()">Login</button>
+    <p id="msg"></p>
+    <p><a href="/static/index.html">Back to Home</a></p>
+
+    <script>
+        async function loginAdmin() {
+            const phone = document.getElementById('phone').value.trim();
+            if (!phone) {
+                document.getElementById('msg').textContent = 'Enter phone number';
+                document.getElementById('msg').style.color = 'red';
+                return;
+            }
+            document.getElementById('msg').textContent = '';
+            const res = await fetch('/admin/login', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ phone_number: phone })
+            });
+            const data = await res.json();
+            if (res.ok) {
+                localStorage.setItem('access_token', data.access_token);
+                window.location.href = '/static/admin_dashboard.html';
+            } else {
+                document.getElementById('msg').textContent = data.detail || 'Error';
+                document.getElementById('msg').style.color = 'red';
+            }
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add admin phone-based login page
- handle GET/POST routes at `/admin/login` for phone login

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68768c75ef4c832f9bb0c9227aa3f620