### PR TITLE
Add buttons for buying products on landing page

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -126,6 +126,21 @@
       width: auto;
       flex: 1;
     }
+
+    /* buttons for product actions */
+    .product-btn {
+      background-color: #4CAF50;
+      color: white;
+      border: none;
+      padding: 8px 12px;
+      border-radius: 4px;
+      cursor: pointer;
+      margin: 5px 2px;
+    }
+
+    .product-btn:hover {
+      background-color: #45a049;
+    }
   </style>
 </head>
 
@@ -186,15 +201,39 @@
       }
       products.forEach(p => {
         const li = document.createElement("li");
+        const nameEsc = p.name.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+        const firstImage = p.image_urls[0] || "";
+        const imgEsc = firstImage.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
         li.innerHTML = `
           ${p.image_urls.map(url => `<img src="${url}" alt="${p.name}" width="100" height="100">`).join("")}<br/>
           <strong>${p.name}</strong><br/>
           ${p.description ? `<span>${p.description}</span><br/>` : ""}
           ₹${p.price.toFixed(2)}<br/>
-          Delivery Range: ${p.delivery_range_km} km
+          Delivery Range: ${p.delivery_range_km} km<br/>
+          <button class="product-btn" onclick="buyProduct(${p.id}, '${nameEsc}', ${p.price}, '${imgEsc}')">Buy</button>
+          <button class="product-btn" onclick="addToCart(${p.id}, '${nameEsc}', ${p.price}, '${imgEsc}')">Add to Cart</button>
+          <button class="product-btn" onclick="window.location.href='/static/buyer_orders.html'">My Orders</button>
         `;
         list.appendChild(li);
       });
+    }
+
+    function buyProduct(id, name, price, imageUrl) {
+      addToCart(id, name, price, imageUrl);
+      window.location.href = "/static/cart.html";
+    }
+
+    function addToCart(id, name, price, imageUrl) {
+      const cart = JSON.parse(localStorage.getItem("cart")) || [];
+      const existing = cart.find(item => item.id === id);
+      if (existing) {
+        existing.qty += 1;
+        if (!existing.imageUrl && imageUrl) existing.imageUrl = imageUrl;
+      } else {
+        cart.push({ id, name, price, imageUrl, qty: 1 });
+      }
+      localStorage.setItem("cart", JSON.stringify(cart));
+      alert(`${name} added to cart.`);
     }
 
     window.addEventListener("DOMContentLoaded", loadPublicProducts);


### PR DESCRIPTION
## Summary
- make new `.product-btn` green style
- list action buttons when rendering products on the index page
- enable buying and cart functionality from landing page

## Testing
- `python -m py_compile main.py models.py database.py schemas.py`

------
https://chatgpt.com/codex/tasks/task_e_6877754ef458832fb0a9ac9a59045153