### PR TITLE
Protect admin dashboard access

### DIFF
--- a/main.py
+++ b/main.py
@@ -1236,5 +1236,12 @@ async def admin_login(
 
     # Return a dummy access token for now
     access_token = create_access_token({"phone_number": phone_number})
-    
+
     return JSONResponse(content={"access_token": access_token})
+
+
+# Endpoint to verify admin token validity
+@app.get("/admin/check", include_in_schema=False)
+def admin_check(current_admin: Admin = Depends(get_current_admin_from_token)):
+    """Return OK if provided token belongs to a valid admin."""
+    return {"status": "ok"}

--- a/static/admin_dashboard.html
+++ b/static/admin_dashboard.html
@@ -98,7 +98,22 @@
             if (res.ok) loadProducts();
             else alert('Failed to delete');
         }
-        loadProducts();
+        if(!token){
+            window.location.href = '/static/index.html';
+        }else{
+            fetch('/admin/check', {headers:{Authorization: 'Bearer ' + token}})
+                .then(res => {
+                    if(res.ok){
+                        loadProducts();
+                    }else{
+                        localStorage.removeItem('access_token');
+                        window.location.href = '/static/index.html';
+                    }
+                })
+                .catch(() => {
+                    window.location.href = '/static/index.html';
+                });
+        }
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- guard `admin_dashboard.html` behind login
- add `/admin/check` endpoint to verify admin token

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_687777662658832f850e57db47e594b1