### PR TITLE
Add scroll message on home page

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -167,6 +167,7 @@
       <button onclick="window.location.href='static/shop_register.html'">Start Selling</button>
       <button onclick="window.location.href='static/ask_phone.html'">My Products</button>
     </div>
+    <p class="about-text">Scroll down to see the listed products and buy.</p>
   </div>
 
   <div class="info-card card" id="product-section">


### PR DESCRIPTION
## Summary
- add a short note on the home page telling visitors to scroll down for products

## Testing
- `python -m py_compile main.py models.py database.py schemas.py`

------
https://chatgpt.com/codex/tasks/task_e_68777c16c268832fb2ce9c8874b5f2ff