### PR TITLE
Restrict admin dashboard access

### DIFF
--- a/main.py
+++ b/main.py
@@ -1185,8 +1185,14 @@ def get_all_orders(
 
 
 @app.get("/admin", include_in_schema=False)
-async def admin_dashboard_page():
-    """Serve the admin dashboard HTML."""
+async def admin_dashboard_page(current_user: Admin = Depends(get_current_admin_from_token)):
+    """Serve the admin dashboard HTML if the requester is an admin."""
+    return FileResponse("static/admin_dashboard.html")
+
+
+@app.get("/static/admin_dashboard.html", include_in_schema=False)
+async def admin_dashboard_static(current_user: Admin = Depends(get_current_admin_from_token)):
+    """Serve the admin dashboard from the static path with auth."""
     return FileResponse("static/admin_dashboard.html")
 
 


### PR DESCRIPTION
## Summary
- protect `/admin` route so only admins with valid tokens can load the dashboard
- override `/static/admin_dashboard.html` with the same check so direct access requires authentication

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68777c7f6010832fbe6cc9c462c30794