### PR TITLE
Add single shop view for admin

### DIFF
--- a/main.py
+++ b/main.py
@@ -1139,6 +1139,24 @@ def admin_delete_product(
     db.commit()
     return {"msg": "Product deleted"}
 
+
+@app.get("/admin/shop/{phone_number}")
+def admin_get_shop(
+    phone_number: str,
+    current_user: dict = Depends(get_current_admin_from_token),
+    db: Session = Depends(get_db),
+):
+    """Return shop details for the given phone number."""
+    require_admin(current_user)
+    shop = db.query(Shop).filter(Shop.phone_number == phone_number).first()
+    if not shop:
+        raise HTTPException(status_code=404, detail="Shop not found")
+    return {
+        "name": shop.name,
+        "address": shop.address,
+        "phone_number": shop.phone_number,
+    }
+
 @app.post("/verify-shop")
 def verify_shop(request: PhoneCheckRequest, db: Session = Depends(get_db)):
     shop = db.query(Shop).filter(Shop.phone_number == request.phone_number).first()

--- a/static/admin_sellers.html
+++ b/static/admin_sellers.html
@@ -49,11 +49,14 @@
 </head>
 <body>
     <a href="/static/admin_dashboard.html">&larr; Back to Dashboard</a>
-    <h2>Registered Sellers</h2>
+    <h2 id="page-title">Registered Sellers</h2>
     <div id="seller-list">Loading...</div>
 
     <script>
         const token = localStorage.getItem('access_token');
+        const params = new URLSearchParams(window.location.search);
+        const phone = params.get('phone');
+
         async function loadSellers() {
             const res = await fetch('/admin/sellers/details', {
                 headers: { Authorization: 'Bearer ' + token }
@@ -90,6 +93,41 @@
                 list.appendChild(item);
             });
         }
+
+        async function loadSeller(phone) {
+            document.getElementById('page-title').textContent = 'Shop Details';
+            const infoRes = await fetch(`/admin/shop/${encodeURIComponent(phone)}`, {
+                headers: { Authorization: 'Bearer ' + token }
+            });
+            const prodRes = await fetch(`/api/products/by-phone/${encodeURIComponent(phone)}`, {
+                headers: { Authorization: 'Bearer ' + token }
+            });
+            const container = document.getElementById('seller-list');
+            container.innerHTML = '';
+            if (!infoRes.ok) {
+                container.textContent = 'Shop not found.';
+                return;
+            }
+            const info = await infoRes.json();
+            const products = prodRes.ok ? await prodRes.json() : [];
+            const item = document.createElement('div');
+            item.className = 'seller';
+            const productHtml = products.length ? products.map(p => `
+                <li class="product">
+                    ${p.image_urls.map(url => `<img src="${url.startsWith('/') ? url : '/' + url}" alt="${p.name}">`).join('')}
+                    <strong>${p.name}</strong> - ₹${p.price} ${p.description || ''}
+                    <button onclick="deleteProduct(${p.id})">Delete</button>
+                </li>
+            `).join('') : '<li>No products</li>';
+            item.innerHTML = `
+                <strong>${info.name}</strong><br>
+                Address: ${info.address}<br>
+                Phone: ${info.phone_number}<br>
+                <ul>${productHtml}</ul>
+            `;
+            container.appendChild(item);
+        }
+
         async function deleteProduct(id) {
             if (!confirm('Delete this product?')) return;
             const res = await fetch(`/admin/products/${id}`, {
@@ -97,12 +135,16 @@
                 headers: { Authorization: 'Bearer ' + token }
             });
             if (res.ok) {
-                loadSellers();
+                phone ? loadSeller(phone) : loadSellers();
             } else {
                 alert('Failed to delete');
             }
         }
-        loadSellers();
+        if (phone) {
+            loadSeller(phone);
+        } else {
+            loadSellers();
+        }
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `/admin/shop/{phone_number}` endpoint
- enhance admin_sellers.html to optionally show a single shop using `?phone=<number>`
- keep delete functionality intact

## Testing
- `python -m py_compile main.py models.py schemas.py`


------
https://chatgpt.com/codex/tasks/task_e_68777f2fa270832f910d60d3156fb629