### PR TITLE
Add button to jump to products on index

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -166,8 +166,8 @@
     <div class="button-row">
       <button onclick="window.location.href='static/shop_register.html'">Start Selling</button>
       <button onclick="window.location.href='static/ask_phone.html'">My Products</button>
+      <button onclick="scrollToProducts()">View Products</button>
     </div>
-    <p class="about-text">Scroll down to see the listed products and buy.</p>
   </div>
 
   <div class="info-card card" id="product-section">
@@ -243,6 +243,10 @@
       }
       localStorage.setItem("cart", JSON.stringify(cart));
       alert(`${name} added to cart.`);
+    }
+
+    function scrollToProducts() {
+      document.getElementById('product-section').scrollIntoView({behavior: 'smooth'});
     }
 
     window.addEventListener("DOMContentLoaded", loadPublicProducts);


### PR DESCRIPTION
## Summary
- add "View Products" button to replace text that instructed users to scroll
- implement `scrollToProducts()` which scrolls smoothly to the products section

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6877b887234c832fa64e8f712d575cf0