### PR TITLE
Fix cart 'Back to Products' link

### DIFF
--- a/static/cart.html
+++ b/static/cart.html
@@ -246,7 +246,8 @@
         }
 
         function goBack() {
-            window.location.href = "/static/buyers.html";
+            // Navigate to the public product list on the home page
+            window.location.href = "/static/index.html#product-section";
         }
 
         function openCartModal(src) {


### PR DESCRIPTION
## Summary
- ensure the cart's **Back to Products** button takes visitors to the product list on the main page

## Testing
- `python3 -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6877c4da91bc832f83a331c20ab65192