### PR TITLE
Fix image path in index.html

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -212,7 +212,7 @@
         const firstImage = p.image_urls[0] || "";
         const imgEsc = firstImage.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
         li.innerHTML = `
-          ${p.image_urls.map(url => `<img src="/static/uploads/${url}" alt="${p.name}" width="100" height="100">`).join("")}<br/>
+          ${p.image_urls.map(url => `<img src="${url.startsWith('/') ? url : '/' + url}" alt="${p.name}" width="100" height="100">`).join("")}<br/>
           <strong>${p.name}</strong><br/>
           ${p.description ? `<span>${p.description}</span><br/>` : ""}
           ₹${p.price.toFixed(2)}<br/>


### PR DESCRIPTION
## Summary
- ensure image URLs aren't double-prefixed in the main product list

## Testing
- `python -m py_compile main.py models.py database.py schemas.py`

------
https://chatgpt.com/codex/tasks/task_e_6877c8660b64832fb7ae3ac7aafa5981