### PR TITLE
Document uploads directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,10 @@ Kinbech/
 ├── requirements.txt  # Required packages
 ```
 
+`static/uploads` is intentionally kept almost empty other than placeholder
+images such as `Kinbechlogo.jpg`. Any pictures uploaded by users are stored in
+this folder at runtime and are not tracked in version control.
+
 ---
 
 ## About the Developer


### PR DESCRIPTION
## Summary
- describe why `static/uploads` is mostly empty

## Testing
- `ls -a static/uploads`

------
https://chatgpt.com/codex/tasks/task_e_6877f4e8bf50832f921434bae4690e73