### PR TITLE
Fix storing multiple uploaded images

### DIFF
--- a/main.py
+++ b/main.py
@@ -523,7 +523,7 @@ async def create_product(
         image_path = upload_dir / filename
         with open(image_path, "wb") as buffer:
             buffer.write(await image.read())
-    image_urls.append(f"/static/uploads/{filename}")
+        image_urls.append(f"/static/uploads/{filename}")
 
     new_product = DBProduct(  # ✅ correct model (SQLAlchemy)
         name=name,


### PR DESCRIPTION
## Summary
- fix image upload loop to append each file path

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6877f4e7956c832fa52754a93eee6e24