### PR TITLE
Add product like button

### DIFF
--- a/main.py
+++ b/main.py
@@ -556,6 +556,7 @@ async def create_product(
         is_validated=False,
         delivery_range_km=delivery_range_km,
         phone_number=phone_number,
+        likes=0,
     )
 
 
@@ -586,6 +587,7 @@ async def get_products(
             "image_urls": p.image_url.split(","),
             "delivery_range_km": p.delivery_range_km,
             "expiry_datetime": p.expiry_datetime,
+            "likes": p.likes,
         }
 
         if "admin" in current_user["role"]:
@@ -607,6 +609,7 @@ async def get_public_products(db: Session = Depends(get_db)):
             "price": p.price,
             "image_urls": p.image_url.split(","),
             "delivery_range_km": p.delivery_range_km,
+            "likes": p.likes,
         })
     return products
 
@@ -781,6 +784,7 @@ async def get_my_products(
             "price": p.price,
             "image_urls": p.image_url.split(","),
             "delivery_range_km": p.delivery_range_km,
+            "likes": p.likes,
         }
         if "admin" in current_user["role"]:
             item["shop_name"] = p.shop_name
@@ -804,6 +808,7 @@ def get_products_by_phone(
             "price": p.price,
             "image_urls": p.image_url.split(","),
             "delivery_range_km": p.delivery_range_km,
+            "likes": p.likes,
         }
         # Optional fields if they exist on the model
         if hasattr(p, "expiry_datetime"):
@@ -1073,11 +1078,22 @@ def get_product_public(product_id: int, db: Session = Depends(get_db)):
         "name": product.name,
         "description": product.description,
         "price": product.price,
-        
+
         "delivery_range_km": product.delivery_range_km,
-        
+
         "image_urls": product.image_url.split(","),
+        "likes": product.likes,
     }
+
+
+@app.post("/products/{product_id}/like")
+def like_product(product_id: int, db: Session = Depends(get_db)):
+    product = db.query(DBProduct).filter(DBProduct.id == product_id).first()
+    if not product:
+        raise HTTPException(status_code=404, detail="Product not found")
+    product.likes = (product.likes or 0) + 1
+    db.commit()
+    return {"likes": product.likes}
 
 # Load HTML templates from the same directory as other static files
 templates = Jinja2Templates(directory="static")

--- a/models.py
+++ b/models.py
@@ -30,6 +30,7 @@ class Product(Base):
     description = Column(String)
     price = Column(String)
     image_url = Column(String)  # Add this line
+    likes = Column(Integer, default=0)
     is_validated = Column(Boolean, default=False)
     delivery_range_km = Column(Integer)
     phone_number = Column(String, unique=True, nullable=False)

--- a/schemas.py
+++ b/schemas.py
@@ -9,5 +9,6 @@ class ProductOut(BaseModel):
     price: str
     delivery_range_km: int
     image_urls: List[str]
+    likes: int | None = 0
 
     model_config = {"from_attributes": True}

--- a/static/buyers.html
+++ b/static/buyers.html
@@ -195,6 +195,7 @@
     <button class="product-btn" onclick="buyProduct(${p.id}, '${nameEsc}', '${p.price}', '${imageEsc}')">Buy</button>
     <button class="product-btn" onclick="addToCart(${p.id}, '${nameEsc}', '${p.price}', '${imageEsc}')">Add to Cart</button>
     <button class="product-btn" onclick="window.location.href='/static/ask_orders_phone.html'">My Orders</button>
+    <button class="product-btn" onclick="likeProduct(${p.id})">Like (<span id="like-count-${p.id}">${p.likes || 0}</span>)</button>
   </div>
 `;
 
@@ -303,6 +304,18 @@
 
             localStorage.setItem("cart", JSON.stringify(cart));
             alert(`${name} added to cart.`);
+        }
+
+        async function likeProduct(id) {
+            try {
+                const res = await fetch(`/products/${id}/like`, { method: "POST" });
+                if (!res.ok) throw new Error();
+                const data = await res.json();
+                const span = document.getElementById(`like-count-${id}`);
+                if (span) span.textContent = data.likes;
+            } catch (e) {
+                alert("Could not like product");
+            }
         }
 
         function viewCart() {

--- a/static/index.html
+++ b/static/index.html
@@ -297,6 +297,7 @@ function renderProducts(products) {
         <button class="product-btn" onclick="buyProduct(${p.id}, '${nameEsc}', '${p.price}', '${imgEsc}')">Buy</button>
         <button class="product-btn" onclick="addToCart(${p.id}, '${nameEsc}', '${p.price}', '${imgEsc}')">Add to Cart</button>
         <button class="product-btn" onclick="window.location.href='/static/ask_orders_phone.html'">My Orders</button>
+        <button class="product-btn" onclick="likeProduct(${p.id})">Like (<span id="like-count-${p.id}">${p.likes || 0}</span>)</button>
       </div>
     `;
 
@@ -330,6 +331,18 @@ function filterProducts() {
       }
       localStorage.setItem("cart", JSON.stringify(cart));
       alert(`${name} added to cart.`);
+    }
+
+    async function likeProduct(id) {
+      try {
+        const res = await fetch(`/products/${id}/like`, { method: "POST" });
+        if (!res.ok) throw new Error();
+        const data = await res.json();
+        const span = document.getElementById(`like-count-${id}`);
+        if (span) span.textContent = data.likes;
+      } catch (e) {
+        alert("Could not like product");
+      }
     }
 
     function scrollToProducts() {


### PR DESCRIPTION
## Summary
- allow recording likes for products in the database
- include likes in API responses
- support liking a product through new endpoint
- display a Like button on product listings

## Testing
- `python -m py_compile main.py models.py schemas.py`

------
https://chatgpt.com/codex/tasks/task_e_687e6e46604c832f9f3cea95a636d485