### PR TITLE
Fix order totals to include service fee

### DIFF
--- a/main.py
+++ b/main.py
@@ -114,6 +114,9 @@ APP_BASE_URL = os.getenv("APP_BASE_URL", "http://127.0.0.1:8000")
 # Domain suffix for usernames
 USERNAME_DOMAIN = "kinbech.shop"
 
+# Flat service fee added to each order total
+SERVICE_FEE = 2.0
+
 # Password hashing
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
@@ -844,7 +847,8 @@ def get_seller_orders(
                 }
                 for item in order.items
             ],
-            "total": sum(price_to_float(item.product.price) * item.quantity for item in order.items),
+            "total": sum(price_to_float(item.product.price) * item.quantity for item in order.items)
+            + SERVICE_FEE,
             "timestamp": order.timestamp.isoformat(),
             "status": order.status,
         }
@@ -965,7 +969,8 @@ def get_buyer_orders(
                 }
                 for item in o.items
             ],
-            "total": sum(price_to_float(item.product.price) * item.quantity for item in o.items),
+            "total": sum(price_to_float(item.product.price) * item.quantity for item in o.items)
+            + SERVICE_FEE,
             "status": o.status,
             "timestamp": o.timestamp.isoformat(),
         }
@@ -999,9 +1004,11 @@ def get_orders_by_phone(phone_number: str, db: Session = Depends(get_db)):
                     for item in o.items
                 ],
                 "total": sum(
-                    price_to_float(item.product.price if item.product else "0") * item.quantity
+                    price_to_float(item.product.price if item.product else "0")
+                    * item.quantity
                     for item in o.items
-                ),
+                )
+                + SERVICE_FEE,
                 "status": o.status,
                 "timestamp": o.timestamp.isoformat(),
             }
@@ -1251,9 +1258,11 @@ def get_all_orders(
                     for item in order.items
                 ],
                 "total": sum(
-                    price_to_float(item.product.price if item.product else "0") * item.quantity
+                    price_to_float(item.product.price if item.product else "0")
+                    * item.quantity
                     for item in order.items
-                ),
+                )
+                + SERVICE_FEE,
                 "timestamp": order.timestamp.isoformat(),
                 "status": order.status,
             }

--- a/static/admin_orders.html
+++ b/static/admin_orders.html
@@ -54,7 +54,7 @@
                     <strong>Buyer:</strong> ${o.buyer} ${o.phone_number ? '(' + o.phone_number + ')' : ''}<br>
                     Address: ${o.address}<br>
                     ${o.items.map(i => `${i.shop_name ? i.shop_name + ': ' : ''}${i.name} x${i.quantity} - ₹${(parseFloat(i.price) * i.quantity).toFixed(2)}`).join('<br>')}<br>
-                    <strong>Total: ₹${o.total.toFixed(2)}</strong><br>
+                    <strong>Total: ₹${o.total.toFixed(2)} (+2 rs kinbech service)</strong><br>
                     Status: ${o.status}<br>
                     Time: ${new Date(o.timestamp).toLocaleString()}<br>
                     ${fulfillBtn} ${completeBtn}

--- a/static/buyer_orders.html
+++ b/static/buyer_orders.html
@@ -64,7 +64,7 @@
                     div.innerHTML = `
                         Address: ${o.address}<br>
                         ${o.items.map(i => `${i.shop_name ? i.shop_name + ': ' : ''}${i.name} x${i.quantity} - ₹${(parseFloat(i.price) * i.quantity).toFixed(2)}`).join('<br>')}<br>
-                        <strong>Total: ₹${o.total.toFixed(2)}</strong><br>
+                        <strong>Total: ₹${o.total.toFixed(2)} (+2 rs kinbech service)</strong><br>
                         Status: ${o.status}<br>
                         Time: ${new Date(o.timestamp).toLocaleString()}<br>
                         ${completeBtn}

--- a/static/cart.html
+++ b/static/cart.html
@@ -227,6 +227,7 @@ async function placeOrder() {
         };
         console.log("📦 Final Payload JSON:", JSON.stringify(payload, null, 2));
 
+        const orderedItems = cart.slice();
         const res = await fetch("/checkout", {
             method: "POST",
             headers: {
@@ -259,7 +260,10 @@ if (!res.ok) throw new Error(data.detail || "Order failed");
         document.getElementById("phone-number").value = "";
         document.getElementById("secondary-phone").value = "";
         document.getElementById("message").style.color = "green";
-        document.getElementById("message").textContent = data.msg || "Order placed successfully!";
+        const details = orderedItems
+            .map(i => `Product Name: ${i.name} Description: ${i.description || 'N/A'} Price: ₹${parseFloat(i.price).toFixed(2)}`)
+            .join('\n');
+        document.getElementById("message").textContent = (data.msg || "Order placed successfully!") + "\n" + details;
         renderCart();
     } catch (err) {
         document.getElementById("message").style.color = "red";

--- a/static/orders.html
+++ b/static/orders.html
@@ -66,7 +66,7 @@
                 ${item.shop_name ? item.shop_name + ' - ' : ''}${item.name} x${item.quantity} - ₹${(parseFloat(item.price) * item.quantity).toFixed(2)}<br/>
               `).join("")}
               Address: ${order.address}<br/>
-              <strong>Total: ₹${order.total.toFixed(2)}</strong><br/>
+              <strong>Total: ₹${order.total.toFixed(2)} (+2 rs kinbech service)</strong><br/>
               Status: <span class="${order.status === 'Fulfilled' ? 'fulfilled' : ''}">${order.status}</span><br/>
               ${order.status !== "Fulfilled" ? `<button onclick="markFulfilled(${order.id})">Mark as Fulfilled</button>` : ""}
             </div>


### PR DESCRIPTION
## Summary
- add `SERVICE_FEE` constant
- include the fee when calculating totals for seller, buyer, phone, and admin order APIs
- show the service fee on order pages
- list ordered items in the success message on checkout

## Testing
- `python -m py_compile main.py models.py`


------
https://chatgpt.com/codex/tasks/task_e_687f56149df0832fba7be19ea62b2876