### PR TITLE
Fix product list image preview

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -280,11 +280,13 @@ function renderProducts(products) {
     // Move this declaration BEFORE using it
     const encodedImages = encodeURIComponent(JSON.stringify(imageUrls));
 
+    // Show only the first image as a preview. Clicking it will open the
+    // modal where users can navigate through all available images.
     let imageHTML = '';
-    imageUrls.forEach((url, index) => {
-      const safeUrl = url.trim();
-      imageHTML += `<img src="${safeUrl}" alt="${p.name}" width="100" height="100" style="margin: 5px; cursor:pointer;" onclick="openImageViewer('${encodedImages}', ${index})">`;
-    });
+    if (imageUrls.length > 0) {
+      const safeUrl = imageUrls[0].trim();
+      imageHTML = `<img src="${safeUrl}" alt="${p.name}" width="100" height="100" style="margin: 5px; cursor:pointer;" onclick="openImageViewer('${encodedImages}', 0)">`;
+    }
 
     li.innerHTML = `
       ${imageHTML}


### PR DESCRIPTION
## Summary
- display only the first product image on the public product list
- keep modal navigation for additional images

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687f5ec4391c832fa90719325a04d4c3