### PR TITLE
Implement basic product likes

### DIFF
--- a/models.py
+++ b/models.py
@@ -112,6 +112,16 @@ class AddedProduct(Base):
     user = relationship("UserModel")
 
 
+class Like(Base):
+    """Simple like count for each product."""
+
+    __tablename__ = "like"
+
+    id = Column(Integer, primary_key=True, index=True)
+    product_id = Column(Integer, ForeignKey("products.id"))
+    like = Column(Integer, default=0)
+
+
 class CheckoutItem(BaseModel):
     product_id: int
     quantity: int

--- a/static/index.html
+++ b/static/index.html
@@ -154,6 +154,9 @@
     .product-btn:hover {
       background-color: #45a049;
     }
+    .like-btn { display:flex; align-items:center; gap:2px; }
+    .like-btn .heart { color:white; }
+    .like-btn.liked .heart { color:red; }
 
     #imageModal {
   transition: opacity 0.3s ease-in-out;
@@ -297,6 +300,7 @@ function renderProducts(products) {
         <button class="product-btn" onclick="buyProduct(${p.id}, '${nameEsc}', '${p.price}', '${imgEsc}')">Buy</button>
         <button class="product-btn" onclick="addToCart(${p.id}, '${nameEsc}', '${p.price}', '${imgEsc}')">Add to Cart</button>
         <button class="product-btn" onclick="window.location.href='/static/ask_orders_phone.html'">My Orders</button>
+        <button class="product-btn like-btn" onclick="likeProduct(${p.id}, this)"><span class="heart">♡</span> <span class="count">${p.likes}</span></button>
       </div>
     `;
 
@@ -330,6 +334,24 @@ function filterProducts() {
       }
       localStorage.setItem("cart", JSON.stringify(cart));
       alert(`${name} added to cart.`);
+    }
+
+    async function likeProduct(id, btn) {
+      try {
+        const res = await fetch(`/products/${id}/like`, { method: "POST" });
+        if (res.ok) {
+          const data = await res.json();
+          const heart = btn.querySelector(".heart");
+          const count = btn.querySelector(".count");
+          if (heart && count) {
+            count.textContent = data.likes;
+            heart.textContent = "\u2665"; // filled heart
+            btn.classList.add("liked");
+          }
+        }
+      } catch (e) {
+        console.error("Failed to like", e);
+      }
     }
 
     function scrollToProducts() {


### PR DESCRIPTION
## Summary
- introduce `Like` model to store per-product likes
- expose like counts on `/public-products`
- add `/products/{product_id}/like` endpoint to increment likes
- show heart-shaped like button on the public product list which turns red when liked

## Testing
- `python -m py_compile main.py models.py schemas.py database.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687f50324d0c832f89880318d900a2c2